### PR TITLE
feat: Definindo um padrão em props

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,13 +7,18 @@ function Page(){
     <div>
       <h1>Olá mundo</h1>
       <Geo/>
-      <Person 
+      <Person
         name="Elon Musk Props"
         avatar= 'https://files.sunoresearch.com.br/p/uploads/2018/09/Elon-Musk-2-400x300.jpg'
+        roles= {['Ceo da Tesla', 'Ceo da Spacex']}
+      />
+      <Person
+        name="Homem sem avatar"
+        
         roles= {['Ceo da Tesla', 'Ceo da Spacex']}
       />
     </div>
   )
 }
 
-export default Page;
+export default Page; 

--- a/src/components/Person.tsx
+++ b/src/components/Person.tsx
@@ -1,18 +1,23 @@
+import { Pinyon_Script } from "next/font/google"
+
 type Props = {
   name: string,
-  avatar: string,
+  avatar?: string,
   roles: string[],
   address?: string //valor opcional, pode ou não receber valores por parâmetros.
 }
 
 
-export const Person = ({name, avatar, roles}: Props) => {
+export const Person = ({name, 
+  avatar = 'https://st3.depositphotos.com/1767687/17621/v/1600/depositphotos_176214104-stock-illustration-default-avatar-profile-icon.jpg', 
+  roles
+}: Props) => {
   
   return (
       <>
         <h1>{name}</h1>
         <img 
-          src={avatar} 
+          src={avatar}
           alt={name}
           className="w-40"
         />


### PR DESCRIPTION
Valor padrão de props.
Basta colocar a propriedade como opcional e nos parâmetros do componente setar um valor padrão.

Propriedade opcional: aqui colocaremos avatar como opcional.

```typescript
type Props = {
  name: string,
  avatar?: string,
  roles: string[],
  address?: string //valor opcional, pode ou não receber valores por parâmetros.
}
``` 

Valor padrão no parâmetro do componente: 

```typescript
export const Person = ({name, 
  avatar = 'https://st3.depositphotos.com/1767687/17621/v/1600/depositphotos_176214104-stock-illustration-default-avatar-profile-icon.jpg', 
  roles
}: Props) => { ...}
``` 

Agora podemos invocar o componente sem enviar o avatar e ele usará o valor padrão.

```typescript
 <Person
        name="Homem sem avatar"
        
        roles= {['Ceo da Tesla', 'Ceo da Spacex']}
      />
``` 